### PR TITLE
Fix references to uredis_modular

### DIFF
--- a/docs/micropython_redis.rst
+++ b/docs/micropython_redis.rst
@@ -10,25 +10,25 @@ Module
     :inherited-members:
     :show-inheritance:
 
-.. automodule:: uredisi_modular.client
+.. automodule:: uredis_modular.client
     :synopsis: Redis client
     :members:
     :inherited-members:
     :show-inheritance:
 
-.. automodule:: uredisi_modular.connection
+.. automodule:: uredis_modular.connection
     :synopsis: Redis client with only Redis Connection command functionality
     :members:
     :inherited-members:
     :show-inheritance:
 
-.. automodule:: uredisi_modular.keys
+.. automodule:: uredis_modular.keys
     :synopsis: Redis client with Redis Keys command functionality
     :members:
     :inherited-members:
     :show-inheritance:
 
-.. automodule:: uredisi_modular.list
+.. automodule:: uredis_modular.list
     :synopsis: Redis client with Redis Lists command functionality
     :members:
     :inherited-members:
@@ -48,86 +48,86 @@ uredis.StrictRedis() Class
    :inherited-members:
    :show-inheritance:
 
-uredisi_modular.connection.Connection() Class
+uredis_modular.connection.Connection() Class
 =============================================
-.. autoclass:: uredisi_modular.connection.Connection
+.. autoclass:: uredis_modular.connection.Connection
    :members:
    :inherited-members:
    :show-inheritance:
 
-uredisi_modular.geo.Geo() Class
+uredis_modular.geo.Geo() Class
 ===============================
-.. autoclass:: uredisi_modular.geo.Geo
+.. autoclass:: uredis_modular.geo.Geo
    :members:
    :inherited-members:
    :show-inheritance:
 
-uredisi_modular.hash.Hash() Class
+uredis_modular.hash.Hash() Class
 =================================
-.. autoclass:: uredisi_modular.hash.Hash
+.. autoclass:: uredis_modular.hash.Hash
    :members:
    :inherited-members:
    :show-inheritance:
 
-uredisi_modular.hyperloglog.HyperLogLog() Class
+uredis_modular.hyperloglog.HyperLogLog() Class
 ===============================================
-.. autoclass:: uredisi_modular.hyperloglog.HyperLogLog
+.. autoclass:: uredis_modular.hyperloglog.HyperLogLog
    :members:
    :inherited-members:
    :show-inheritance:
 
-uredisi_modular.key.Key() Class
+uredis_modular.key.Key() Class
 ===============================
-.. autoclass:: uredisi_modular.key.Key
+.. autoclass:: uredis_modular.key.Key
    :members:
    :inherited-members:
    :show-inheritance:
 
-uredisi_modular.list.List() Class
+uredis_modular.list.List() Class
 =================================
-.. autoclass:: uredisi_modular.list.List
+.. autoclass:: uredis_modular.list.List
    :members:
    :inherited-members:
    :show-inheritance:
 
-uredisi_modular.pubsub.PubSub() Class
+uredis_modular.pubsub.PubSub() Class
 =====================================
-.. autoclass:: uredisi_modular.pubsub.PubSub
+.. autoclass:: uredis_modular.pubsub.PubSub
    :members:
    :inherited-members:
    :show-inheritance:
 
-uredisi_modular.server.Server() Class
+uredis_modular.server.Server() Class
 =====================================
 .. autoclass:: redis.server.Server
    :members:
    :inherited-members:
    :show-inheritance:
 
-uredisi_modular.set.Set() Class
+uredis_modular.set.Set() Class
 ===============================
-.. autoclass:: uredisi_modular.set.Set
+.. autoclass:: uredis_modular.set.Set
    :members:
    :inherited-members:
    :show-inheritance:
 
-uredisi_modular.sortedset.SortedSet() Class
+uredis_modular.sortedset.SortedSet() Class
 ===========================================
-.. autoclass:: uredisi_modular.sortedset.SortedSet
+.. autoclass:: uredis_modular.sortedset.SortedSet
    :members:
    :inherited-members:
    :show-inheritance:
 
-uredisi_modular.string.String() Class
+uredis_modular.string.String() Class
 =====================================
-.. autoclass:: uredisi_modular.string.String
+.. autoclass:: uredis_modular.string.String
    :members:
    :inherited-members:
    :show-inheritance:
 
-uredisi_modular.transaction.Transaction() Class
+uredis_modular.transaction.Transaction() Class
 ===============================================
-.. autoclass:: uredisi_modular.transaction.Transaction
+.. autoclass:: uredis_modular.transaction.Transaction
    :members:
    :inherited-members:
    :show-inheritance:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,7 +29,7 @@ uses about ~6.5kb.  Then each functionality module increases the
 resource usage by 1kb to 6kb depending on the compexity of 
 the functinality submodule.
 
-For example using the redis_modular.list.List() submodule provides
+For example using the uredis_modular.list.List() submodule provides
 all of the redis server List functionality but uses 10kb to import.
 
 ## Low level access using the uredis_modular.client.Client() class


### PR DESCRIPTION
Glanced through log of updates and noticed some references to `uredisi_modular`. Updated references to point to `uredis_modular`.
